### PR TITLE
B4: Braodcasting messages and chatinfo after the client sends a msg

### DIFF
--- a/controllers/chatSession.js
+++ b/controllers/chatSession.js
@@ -1,14 +1,35 @@
 const { catchWebSocketAsync } = require("../common/Utils/appError");
 const { transformMessages, createMessageDoc } = require("../common/Utils/transformers/chatSession");
-const { getAllMessagesOfChat, updateReadByInMessage, getChatInfo, updateLiveMembers, createMessage, updateLastMessageInChat } = require("../repository/chatSession");
+const { transformChatInfo } = require("../common/Utils/transformers/userSession");
+const { getAllMessagesOfChat, updateReadByInMessage, updateLiveMembers, createMessage, updateLastMessageInChat } = require("../repository/chatSession");
+const { getUserChatsFromDb, getUnreadCountByChat } = require("../repository/userSession");
 
-async function broadCastUpdatedMessageInfo(chatId, userId, socket) {
-    const liveMemberInfo = (await getChatInfo(chatId, userId)).liveMembers?.find(({ user }) => user._id.toString() !== userId) || {};
+async function broadCastUpdatedMessageInfo(chatInfo, userId, socket) {
+    const liveMemberInfo = chatInfo.liveMembers?.find(({ user }) => user._id.toString() !== userId) || {};
     if (liveMemberInfo.user && liveMemberInfo.socketId) {
         const { id } = liveMemberInfo.user;
-        const messages = await getAllMessagesOfChat(chatId, id.toString());
-        socket.to(liveMemberInfo.socketId).emit('getMessagesOfChat', { messages: transformMessages(messages, id), chatId });
+        const messages = await getAllMessagesOfChat(chatInfo.id, id.toString());
+        socket.to(liveMemberInfo.socketId).emit('getMessagesOfChat', { messages: transformMessages(messages, id), chatId: chatInfo.id });
     }
+}
+
+async function getChatInfoOfUser(userData) {
+    const { userId } = userData;
+    const chats = await getUserChatsFromDb(userId);
+    const chatIdArr = chats.map(({ _doc }) => _doc._id);
+    const chatInfo = chats.map(({ _doc }) => _doc);
+    const unreadMsgCountByChat = await getUnreadCountByChat(chatIdArr, userId);
+    const transformedChatInfo = transformChatInfo(unreadMsgCountByChat, chatInfo);
+
+    return transformedChatInfo;
+}
+
+function broadCastUpdatedChatInfo(userDataArr, io) {
+    userDataArr.forEach(async ({ id, onlineStatus }) => {
+        const transformedChatInfo = await getChatInfoOfUser({ userId: id });
+        if (onlineStatus.socketId && onlineStatus.status === 'Online')
+            io.of('/araosdevsm/user-session').to(onlineStatus.socketId).emit('getChatInfo', transformedChatInfo);
+    });
 }
 
 exports.sendMessagesInfo = async (data, callback) => {
@@ -17,22 +38,22 @@ exports.sendMessagesInfo = async (data, callback) => {
     callback({ messages: transformMessages(messages, userId), chatId });
 }
 
-exports.handleChatSession = (websocket) => {
+exports.handleChatSession = (websocket, io) => {
     websocket.on('getMessagesOfChat', catchWebSocketAsync(async (data, callback) => {
         const { chatId, userId } = data;
         await this.sendMessagesInfo(data, callback);
         await updateReadByInMessage(chatId, userId);
-        await updateLiveMembers(chatId, userId, websocket.id);
-        await broadCastUpdatedMessageInfo(chatId, userId, websocket);
-    }));
+        const chatInfo = await updateLiveMembers(chatId, userId, websocket.id);
+        await broadCastUpdatedMessageInfo(chatInfo, userId, websocket);
+    }, websocket));
 
     websocket.on('sendMessage', catchWebSocketAsync(async (data, callback) => {
         const { chatId, sentBy, content, type } = data;
         const messageDoc = await createMessageDoc(data);
         const recentMessage = await createMessage(messageDoc);
         await this.sendMessagesInfo({ chatId, userId: sentBy }, callback);
-        await updateLastMessageInChat(chatId, recentMessage);
-        // broadcast updated chatinfo to the sender
-        // broadcast updated chatinfo and updated messages to the user.
+        const chatInfo = await updateLastMessageInChat(chatId, recentMessage);
+        await broadCastUpdatedMessageInfo(chatInfo, sentBy, websocket);
+        broadCastUpdatedChatInfo(chatInfo.members, io);
     }, websocket));
 }

--- a/controllers/userSession.js
+++ b/controllers/userSession.js
@@ -1,6 +1,6 @@
 const { catchWebSocketAsync } = require("../common/Utils/appError");
 const { transformChatInfo } = require("../common/Utils/transformers/userSession");
-const { getUserChatsFromDb, getUnreadCountByChat, updateOnlineStatus, updateMessageDeliveredToUser, updateChatLiveMembers } = require("../repository/userSession");
+const { getUserChatsFromDb, getUnreadCountByChat, updateOnlineStatus, updateMessageDeliveredToUser } = require("../repository/userSession");
 
 async function getChatInfoOfUser(userData) {
     const { userId } = userData;
@@ -13,7 +13,7 @@ async function getChatInfoOfUser(userData) {
     return { transformedChatInfo, chatIdArr, chatInfo };
 }
 
-function broadCastUpdatedChatInfo(socket, userDataArr) {
+exports.broadCastUpdatedChatInfo = (socket, userDataArr) => {
     userDataArr.forEach(async ({ id, onlineStatus }) => {
         const { transformedChatInfo } = await getChatInfoOfUser({ userId: id });
         if (onlineStatus.socketId) socket.to(onlineStatus.socketId).emit('getChatInfo', transformedChatInfo);
@@ -29,6 +29,6 @@ exports.handleUserSession = (websocket) => {
         await updateMessageDeliveredToUser(userId, chatIdArr);
 
         const memberDetails = chatInfo.map(({ members }) => members.map(({ id, onlineStatus }) => ({ id, onlineStatus }))).flat();
-        broadCastUpdatedChatInfo(websocket, memberDetails);
+        this.broadCastUpdatedChatInfo(websocket, memberDetails);
     }, websocket));
 };

--- a/controllers/websocket.js
+++ b/controllers/websocket.js
@@ -1,0 +1,14 @@
+const { Server } = require('socket.io');
+const { handleUserSession } = require('./userSession');
+const { handleChatSession } = require('./chatSession');
+
+let io;
+const socketConnection = (server) => {
+    io = new Server(server);
+    io.of('/araosdevsm/user-session').on('connection', (websocket) => {
+        handleUserSession(websocket, io);
+    });
+    io.of('/araosdevsm/chat-session').on('connection', (websocket) => handleChatSession(websocket, io));
+};
+
+module.exports = { io, socketConnection };

--- a/server.js
+++ b/server.js
@@ -4,9 +4,7 @@ const { createServer } = require('http');
 const mongoose = require('mongoose');
 const app = require('./app');
 const { loggerMsg } = require('./common/constants/global');
-const { Server } = require('socket.io');
-const { handleUserSession } = require('./controllers/userSession');
-const { handleChatSession } = require('./controllers/chatSession');
+const { socketConnection } = require('./controllers/websocket');
 
 
 const { MASTER_DB_ENDPOINT: MASTER_DB, PORT } = process.env;
@@ -14,9 +12,5 @@ const { DB_CONNECTION_SUCCESS, SERVER_CONNECTED } = loggerMsg;
 
 mongoose.connect(MASTER_DB).then(() => console.log(DB_CONNECTION_SUCCESS));
 const httpServer = createServer(app);
-
 httpServer.listen(PORT, () => console.log(SERVER_CONNECTED));
-const io = new Server(httpServer);
-
-io.of('/araosdevsm/user-session').on('connection', handleUserSession);
-io.of('/araosdevsm/chat-session').on('connection', handleChatSession);
+socketConnection(httpServer);


### PR DESCRIPTION
1) Added a send message listener which creates a message and send back the updated messages to the current user.
2) Broadcasts the live members friends of the current user with the updated message info.
3) Broadcasts the online members of the current chat with the updated chatinfo.

Note: Currently the unread count in the updated chatinfo after the user sends a message is wrong. This is a known bug in the current PR.